### PR TITLE
fix: Resolve pathing issue throw by typescipt on Windows.

### DIFF
--- a/src/access.service.spec.ts
+++ b/src/access.service.spec.ts
@@ -15,7 +15,7 @@ import { CaslRequestCache } from './interfaces/casl-request-cache.interface';
 import { SubjectBeforeFilterHook, UserBeforeFilterHook } from 'interfaces/hooks.interface';
 import { AbilityMetadata } from 'interfaces/ability-metadata.interface';
 import { User } from '__specs__/app/user/dtos/user.dto';
-import { AuthorizableRequest } from 'interfaces/request.interface';
+import { AuthorizableRequest } from './interfaces/request.interface';
 
 const permissions: Permissions<Roles, Post> = {
   everyone({ can }) {

--- a/src/casl.module.ts
+++ b/src/casl.module.ts
@@ -6,7 +6,7 @@ import { AccessService } from './access.service';
 import { AbilityFactory } from './factories/ability.factory';
 import { AuthorizableUser } from './interfaces/authorizable-user.interface';
 import { CaslConfig } from './casl.config';
-import { AuthorizableRequest } from 'interfaces/request.interface';
+import { AuthorizableRequest } from './interfaces/request.interface';
 
 @Module({
   imports: [],

--- a/src/proxies/context.proxy.ts
+++ b/src/proxies/context.proxy.ts
@@ -1,9 +1,9 @@
 import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
 import { ContextType, ExecutionContext, NotAcceptableException } from '@nestjs/common';
-import { AuthorizableRequest } from 'interfaces/request.interface';
+import { AuthorizableRequest } from '../interfaces/request.interface';
 
 export class ContextProxy {
-  constructor(private readonly context: ExecutionContext) {}
+  constructor(private readonly context: ExecutionContext) { }
 
   public static create(context: ExecutionContext): ContextProxy {
     return new ContextProxy(context);


### PR DESCRIPTION
Without the relative pathing included in the import, there were errors being thrown by Typescript, which can be seen in issue #165  as well as in the screenshot below. 

![image](https://user-images.githubusercontent.com/11280346/142885863-8b4805a8-f0fe-40fe-836c-86eb6740c0e9.png)

Adding the relative paths resolves this issue. 