### PR TITLE
feat: allow subject tuple to resolve services from the entire module context

### DIFF
--- a/src/factories/subject-hook.factory.ts
+++ b/src/factories/subject-hook.factory.ts
@@ -15,7 +15,8 @@ export class TupleSubjectHook<Service> implements SubjectBeforeFilterHook {
   constructor(
     private service: Service,
     private runFunc: (service: Service, request: AuthorizableRequest) => Promise<AnyObject | undefined>,
-  ) {}
+  ) {
+  }
 
   public async run(request: AuthorizableRequest): Promise<AnyObject | undefined> {
     return this.runFunc(this.service, request);
@@ -31,7 +32,7 @@ export async function subjectHookFactory(
   }
   if (Array.isArray(hookOrTuple)) {
     const [ServiceClass, runFunction] = hookOrTuple;
-    const service = moduleRef.get(ServiceClass);
+    const service = moduleRef.get(ServiceClass, { strict: false });
     return new TupleSubjectHook<typeof ServiceClass>(service, runFunction);
   }
   return moduleRef.create<SubjectBeforeFilterHook>(hookOrTuple);


### PR DESCRIPTION
By passing strict: false into the moduleRef.get we can retrieve services from the entire module context instead of only services provided directly in the module where the hook is instantiated.

 #204