### PR TITLE
fix(user-hook): load global module context

### DIFF
--- a/src/factories/user-hook.factory.ts
+++ b/src/factories/user-hook.factory.ts
@@ -31,7 +31,7 @@ export async function userHookFactory(
   }
   if (Array.isArray(hookOrTuple)) {
     const [ServiceClass, runFunction] = hookOrTuple;
-    const service = moduleRef.get(ServiceClass);
+    const service = moduleRef.get(ServiceClass, { strict: false });
     return new TupleUserHook<typeof ServiceClass>(service, runFunction);
   }
   return moduleRef.create<UserBeforeFilterHook>(hookOrTuple);


### PR DESCRIPTION
https://github.com/getjerry/nest-casl/issues/204
same issue with this on user-hook.factory.
I expect that userhook can load all module at global context