### PR TITLE
Support restricted fields on AccessGuard

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@ucast/core": "^1.10.1",
     "@ucast/mongo": "^2.4.2",
     "@ucast/mongo2js": "^1.3.3",
-    "@ucast/sql": "^1.0.0-alpha.1"
+    "@ucast/sql": "^1.0.0-alpha.1",
+    "dot-object": "^2.1.4"
   },
   "peerDependencies": {
     "@nestjs/apollo": ">= 7.0.0",
@@ -64,6 +65,7 @@
     "@nestjs/testing": "^9.4.0",
     "@swc/core": "^1.2.245",
     "@swc/jest": "^0.2.22",
+    "@types/dot-object": "^2.1.3",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ucast/mongo": "^2.4.2",
     "@ucast/mongo2js": "^1.3.3",
     "@ucast/sql": "^1.0.0-alpha.1",
-    "dot-object": "^2.1.4"
+    "flat": "5.0.2"
   },
   "peerDependencies": {
     "@nestjs/apollo": ">= 7.0.0",
@@ -66,6 +66,7 @@
     "@swc/core": "^1.2.245",
     "@swc/jest": "^0.2.22",
     "@types/dot-object": "^2.1.3",
+    "@types/flat": "^5.0.5",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",

--- a/src/__specs__/app/post/dtos/post.dto.ts
+++ b/src/__specs__/app/post/dtos/post.dto.ts
@@ -10,4 +10,7 @@ export class Post {
 
   @Field({ nullable: true })
   title?: string;
+
+  @Field({ nullable: true })
+  description?: string;
 }

--- a/src/access.service.ts
+++ b/src/access.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Ability, AnyAbility, subject } from '@casl/ability';
 import { AnyObject, Subject } from '@casl/ability/dist/types/types';
-import dot from 'dot-object';
+import { flatten } from 'flat';
 
 import { AuthorizableRequest } from './interfaces/request.interface';
 import { AbilityFactory } from './factories/ability.factory';
@@ -137,7 +137,7 @@ export class AccessService {
   ) {
     if (!user) return true;
 
-    const subjectFields = Object.keys(dot.dot(body));
+    const subjectFields = Object.keys(flatten(body));
 
     return subjectFields.some((field) => !this.hasAbility(user, action, subject, field));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,6 +1983,11 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
+"@types/dot-object@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/dot-object/-/dot-object-2.1.3.tgz#4849b7132af0146c6c402dfcc665f6429c3a5281"
+  integrity sha512-bMBwqKxIdb5Wg9x10TuSSWuZV3CBV67KF+23j+vhXdywJGuqiJikgnSyY/3DTBNF64F+AaWv3Q2pIMbzps4LmQ==
+
 "@types/express-serve-static-core@4.17.31", "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
@@ -3145,6 +3150,11 @@ commander@^2.20.3:
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
@@ -3463,6 +3473,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dot-object@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-2.1.4.tgz#c6c54e9fca510b4d0ea4d65acf33726963843b5f"
+  integrity sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==
+  dependencies:
+    commander "^4.0.0"
+    glob "^7.1.5"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -4177,7 +4195,7 @@ glob@^10.2.2, glob@^10.3.3, glob@^10.3.7:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3, glob@^7.1.4, glob@^7.1.5:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,6 +2007,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/flat@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/flat/-/flat-5.0.5.tgz#2304df0b2b1e6dde50d81f029593e0a1bc2474d3"
+  integrity sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -3150,11 +3155,6 @@ commander@^2.20.3:
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
@@ -3473,14 +3473,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dot-object@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-2.1.4.tgz#c6c54e9fca510b4d0ea4d65acf33726963843b5f"
-  integrity sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==
-  dependencies:
-    commander "^4.0.0"
-    glob "^7.1.5"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -3996,6 +3988,11 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flat@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
@@ -4195,7 +4192,7 @@ glob@^10.2.2, glob@^10.3.3, glob@^10.3.7:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.1.5:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==


### PR DESCRIPTION
related to https://github.com/getjerry/nest-casl/issues/254

### Motivation
Currently, there's no effortless way to support restricted fields by using the `AccessGuard` which requires us to manually call either `hasAbility` or `assertAbility` from `AccessService`.

### Strategy
Get all properties from the body object sent by the client and transform them into dot notation paths, that is the way CASL compares the desired ability against the predefined rules. It's fully compatible with [CASL patterns](https://casl.js.org/v5/en/guide/restricting-fields#field-patterns-table).

### Goal
Deny the request if the user has sent a field in which they don't have permission to perform an action.

