### PR TITLE
Update permission interface in order to correctly type abilities.

### DIFF
--- a/src/interfaces/permissions.interface.ts
+++ b/src/interfaces/permissions.interface.ts
@@ -1,4 +1,4 @@
-import { Ability, AnyAbility, AbilityTuple, AbilityBuilder, Subject } from '@casl/ability';
+import { AbilityBuilder, AbilityTuple, MongoAbility, Subject } from '@casl/ability';
 import { AnyClass } from '@casl/ability/dist/types/types';
 import { DefaultActions } from '../actions.enum';
 import { AuthorizableUser } from './authorizable-user.interface';
@@ -7,11 +7,11 @@ export class UserAbilityBuilder<
   Subjects extends Subject = Subject,
   Actions extends string = DefaultActions,
   User extends AuthorizableUser<unknown, unknown> = AuthorizableUser,
-> extends AbilityBuilder<AnyAbility> {
+> extends AbilityBuilder<MongoAbility<AbilityTuple<Actions, Subjects>>> {
   constructor(
     public user: User,
     public permissions: AnyPermissions<string, Subjects, Actions, User>,
-    AbilityType: AnyClass<Ability<AbilityTuple<Actions, Subjects>>>,
+    AbilityType: AnyClass<MongoAbility<AbilityTuple<Actions, Subjects>>>,
   ) {
     super(AbilityType);
   }


### PR DESCRIPTION
Ability is deprecated, so I updated it to MongoAbility, so ability builder is fully typed as in CASL V6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced ability management by transitioning to a more specific `MongoAbility` type for permissions.
- **Bug Fixes**
	- Updated class and constructor parameter types to improve accuracy in permission definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->